### PR TITLE
Various improvements

### DIFF
--- a/svg-script
+++ b/svg-script
@@ -170,7 +170,7 @@ function addInteractivity(evt) {
             }
         }	
     }
-function clickNode() {
+function clickNode(event) {
     if (nodrag) {
         var nodeName = this.childNodes[1].textContent;
         // Escape special characters in the node name
@@ -200,6 +200,9 @@ function clickNode() {
                 }
             }
         }
+        // Prevent opening a possible URL attached to the node
+        // Note that the URL can still be opened with browser contextual menu (right-click)
+        event.preventDefault()
     }
 }
 function animateEdge(edge){

--- a/svg-script
+++ b/svg-script
@@ -69,7 +69,7 @@
         }
 </style>
 <script>
-<![CDATA[
+//<![CDATA[
 function addInteractivity(evt) {
     
 	var svg = evt.target;
@@ -206,28 +206,32 @@ function clickNode(event) {
     }
 }
 function animateEdge(edge){
-		var path = edge.querySelector('path');
-		var polygon = edge.querySelector('polygon');
-		var length = path.getTotalLength();
-		// Clear any previous transition
-		path.style.transition = path.style.WebkitTransition = 'none';
-		if (polygon){polygon.style.transition = polygon.style.WebkitTransition = 'none';};
-		// Set up the starting positions
-		path.style.strokeDasharray = length + ' ' + length;
-		path.style.strokeDashoffset = length;
-		if(polygon){polygon.style.opacity='0';};
-		// Trigger a layout so styles are calculated & the browser
-		// picks up the starting position before animating
-		path.getBoundingClientRect();
-		// Define our transition
-		path.style.transition = path.style.WebkitTransition =
-		'stroke-dashoffset 2s ease-in-out';
-		if (polygon){polygon.style.transition = polygon.style.WebkitTransition =
-		'fill-opacity 1s ease-in-out 2s';};
-		// Go!
-		path.style.strokeDashoffset = '0';
-        if (polygon){setTimeout(function(){polygon.style.opacity='1';},2000)};
-	}
+    let pathList = edge.querySelectorAll('path');
+    for (let i = 0; i < pathList.length; i++) {
+        let path = pathList[i];
+        let length = path.getTotalLength();
+        // Clear any previous transition
+        path.style.transition = path.style.WebkitTransition = 'none';
+        // Set up the starting positions
+        path.style.strokeDasharray = length + ' ' + length;
+        path.style.strokeDashoffset = length;
+        // Trigger a layout so styles are calculated & the browser
+        // picks up the starting position before animating
+        path.getBoundingClientRect();
+        // Define our transition
+        path.style.transition = path.style.WebkitTransition = 'stroke-dashoffset 2s ease-in-out';
+        path.style.strokeDashoffset = '0';
+    }
+    let polygonList = edge.querySelectorAll('polygon');
+    for (let i = 0; i < polygonList.length; i++) {
+        let polygon = polygonList[i];
+        polygon.style.transition = polygon.style.WebkitTransition = 'none';
+        polygon.style.opacity='0';
+        polygon.style.transition = polygon.style.WebkitTransition = 'fill-opacity 1s ease-in-out 2s';
+        setTimeout(function(){polygon.style.opacity='1';},2000)
+    }
+}
+
 	function addzoomers(cluster){
 
 		var bb = cluster.getBBox();
@@ -594,5 +598,5 @@ function adjustViewBox(svg) {
   var newViewBox = viewBoxParts[0] + " " + newYMin + " " + newXMax + " " + newYMax;
   svg.setAttribute("viewBox", newViewBox);
 }
-]]>
+//]]>
 </script>

--- a/svg-script
+++ b/svg-script
@@ -10,43 +10,41 @@
 }-->
 .text-highlight-nodes text{
     opacity: 1 !important;
-    stroke-width: 10;
-    font-size: 20px;
+    stroke-width: 2;
     font-weight: bold;
     fill: black;
 }
 .text-highlight-edges text{
     opacity: 1 !important;
-    stroke-width: 10;
-    font-size: 20px;
+    stroke-width: 2;
     font-weight: bold;
     fill: Indigo;
 }
 .edge-highlight path{
     opacity: 1;
-    stroke-width: 10;
+    stroke-width: 2;
     stroke: crimson;
 }	
 .edge-highlight polygon{
     opacity: 1;
-    stroke-width: 10;
+    stroke-width: 2;
     stroke: crimson;
 }
 .node-highlight polygon{
     opacity: 1;
-    stroke-width: 10;
+    stroke-width: 2;
     stroke: crimson;
     z-index:99999;	
 }
 .node-highlight ellipse{
     opacity: 1;
-    stroke-width: 10;
+    stroke-width: 2;
     stroke: crimson;
     z-index:99999;	
 }
 .node-highlight path{
     opacity: 1;
-    stroke-width: 10;
+    stroke-width: 2;
     stroke: crimson;
     z-index:99999;	
 }
@@ -178,7 +176,7 @@ function clickNode() {
         // Escape special characters in the node name
         var nodeNameEscaped = nodeName.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&');
 
-        var patroon = new RegExp('^' + nodeNameEscaped + '->|->' + nodeNameEscaped + '$|' + nodeNameEscaped + '--|--' + nodeNameEscaped + '$')
+        var patroon = new RegExp('^' + nodeNameEscaped + '(:\\w+)?->|->' + nodeNameEscaped + '(:\\w+)?$|^' + nodeNameEscaped + '(:\\w+)?--|--' + nodeNameEscaped + '(:\\w+)?$')
 
         if (this.classList.contains("node-highlight")) {
             this.classList.remove("node-highlight");

--- a/svg-script
+++ b/svg-script
@@ -176,7 +176,7 @@ function clickNode(event) {
         // Escape special characters in the node name
         var nodeNameEscaped = nodeName.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&');
 
-        var patroon = new RegExp('^' + nodeNameEscaped + '(:\\w+)?->|->' + nodeNameEscaped + '(:\\w+)?$|^' + nodeNameEscaped + '(:\\w+)?--|--' + nodeNameEscaped + '(:\\w+)?$')
+        var patroon = new RegExp('^' + nodeNameEscaped + '(:\\w+)*->|->' + nodeNameEscaped + '(:\\w+)*$|^' + nodeNameEscaped + '(:\\w+)*--|--' + nodeNameEscaped + '(:\\w+)*$')
 
         if (this.classList.contains("node-highlight")) {
             this.classList.remove("node-highlight");

--- a/update-svg.sh
+++ b/update-svg.sh
@@ -1,0 +1,20 @@
+# Update svg file inplace.
+# To be invoked like this:
+# dot -Tsvg -otransactions.svg transactions.dot && ../../dynamic-SVG-from-Graphviz/update-svg.sh transactions.svg
+
+if [ $# -ne 1 ]
+then
+    echo "Usage: update-svg <svg file path>"
+    exit 1
+fi
+
+echo "Updating $1"
+
+# Insert onload handler in <svg> tag and remove terminating </svg> tag
+sed -i -e 's/<svg /<svg onload="addInteractivity(evt)" /' -e '/<\/svg/d' $1
+
+# Append script
+cat `echo $0 | sed 's/update-svg.sh/svg-script/'` >> $1
+
+# Putback terminating </svg> tag
+echo "</svg>" >> $1


### PR DESCRIPTION
Patroon regexp was enhanced to handle optional port name in edge name. Previously this kind of edge was not highlighted.

Another change is when an url is attached to the node: the click command was opening the url but for consistency with nodes without url, we just want to highlight the node instead. I have added a preventDefault call in click handler to correct this. Note that the url remains accessible with the browser contextual menu (right-click).

I have also added some cosmetic modifications:
- removed "font-size: 20px;" in ".text-highlight-nodes text" and ".text-highlight-edges text" styles to not change shapes footprint (otherwise they tend to collide with neighboring shapes)
- changed "stroke-width: 10;" to "stroke-width: 2;" in all highlight styles (previously width was way too large)

Lastly I have added a bash script that can modify a svg file to automatically incorporate the needed modifications (add onload handler to svg tag and append svg-script content inside svg body). Note that this script was only tested in a git-bash prompt on Windows.
